### PR TITLE
Fix Llama3 prompt format

### DIFF
--- a/pipeline/model_utils/llama3_model.py
+++ b/pipeline/model_utils/llama3_model.py
@@ -12,14 +12,15 @@ from pipeline.model_utils.model_base import ModelBase
 
 # Llama 3 chat templates are based on
 # - https://llama.meta.com/docs/model-cards-and-prompt-formats/meta-llama-3/
+# <|begin_of_text|> is automatically added by the tokenizer
 
-LLAMA3_CHAT_TEMPLATE = """"<|begin_of_text|><|start_header_id|>user<|end_header_id|>
+LLAMA3_CHAT_TEMPLATE = """<|start_header_id|>user<|end_header_id|>
 
 {instruction}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 
 """
 
-LLAMA3_CHAT_TEMPLATE_WITH_SYSTEM = """"<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+LLAMA3_CHAT_TEMPLATE_WITH_SYSTEM = """<|start_header_id|>system<|end_header_id|>
 
 {system_prompt}<|eot_id|><|start_header_id|>user<|end_header_id|>
 


### PR DESCRIPTION
Llama3's tokenizer automatically prepends the <|begin_of_text|> token and one too many " has been left in.

Currently all tokenized prompts start with:

> <|begin_of_text|>"<|begin_of_text|><|start_header_id|> ...

With the change it would be

> <|begin_of_text|><|start_header_id|> ...

Luckily, Llama seems quite robust to slight issues in the prompt format, so it likely did not affect results in any significant way.